### PR TITLE
feat:add post model and create the schema for post

### DIFF
--- a/api/controllers/postController.js
+++ b/api/controllers/postController.js
@@ -4,11 +4,12 @@ export const createPost = async (req, res) => {
   const newPost = new Post(req.body);
   try {
     const savedPost = await newPost.save();
-    res.status(200).json(savedPost);
+    res.status(201).json(savedPost);
   } catch (err) {
     res
       .status(500)
       .json({ message: "Internal server error. Please try again." });
+    console.log(err.message);
   }
 };
 export const updatePost = async (req, res) => {

--- a/api/models/Post.js
+++ b/api/models/Post.js
@@ -1,8 +1,14 @@
 import mongoose from "mongoose";
+import slugify from "slugify";
 
-const PostSchema = new mongoose.Schema(
+const postSchema = new mongoose.Schema(
   {
     title: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    slug: {
       type: String,
       required: true,
       unique: true,
@@ -10,21 +16,41 @@ const PostSchema = new mongoose.Schema(
     desc: {
       type: String,
       required: true,
+      trim: true,
     },
-    photo: {
-      type: String,
-      required: false,
-    },
-    username: {
-      type: String,
+    author: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
       required: true,
     },
+    img: {
+      type: String,
+      default: "",
+    },
     categories: {
-      type: Array,
-      required: false,
+      type: [String],
+      default: [],
+    },
+    likes: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "User",
+      },
+    ],
+    views: {
+      type: Number,
+      default: 0,
     },
   },
   { timestamps: true }
 );
 
-export default mongoose.model("Post", PostSchema);
+// Auto-generate slug from title
+postSchema.pre("validate", function (next) {
+  if (this.title && !this.slug) {
+    this.slug = slugify(this.title, { lower: true, strict: true });
+  }
+  next();
+});
+
+export default mongoose.model("Post", postSchema);

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -15,7 +15,8 @@
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
-        "mongoose": "^8.16.5"
+        "mongoose": "^8.16.5",
+        "slugify": "^1.6.6"
       },
       "devDependencies": {
         "nodemon": "^3.1.10"
@@ -1415,6 +1416,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/sparse-bitfield": {

--- a/api/package.json
+++ b/api/package.json
@@ -17,7 +17,8 @@
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.16.5"
+    "mongoose": "^8.16.5",
+    "slugify": "^1.6.6"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"


### PR DESCRIPTION
Add Post Model and Initial Schema Setup

- Created the Post model with a well-defined Mongoose schema.

- Included fields such as title, slug, desc, author, img, categories, likes, and views.

- Added default values and validation where necessary (e.g., trim, required, unique).

- Implemented a pre-save middleware to auto-generate slugs from the post title.

- Wrote a basic controller function createPost to test post creation.

- Successfully tested post creation using the controller and ensured posts are saved correctly in MongoDB.